### PR TITLE
chore: fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # swaggerhub-custom-rules-library
  Public Custom Rules libary for SwaggerHub API Standardization
 
- Add rules to this repository that can be used in SwaggerHub's API standardiztion
+ Add rules to this repository that can be used in SwaggerHub's API standardization.
 
  YAML Format:
  


### PR DESCRIPTION
"Add rules to this repository that can be used in SwaggerHub's API standardiztion"

Changed last word to "standardization".